### PR TITLE
Token is now optional (env var & ~/.now.json support)

### DIFF
--- a/README.hbs
+++ b/README.hbs
@@ -13,6 +13,8 @@ var Now = require('now-api');
 
 var now = Now('YOUR TOKEN');
 
+If you don't supply 'YOUR TOKEN', it will be searched for in ~/.now.json
+
 // Supports Promises
 now.getDeployments().then((deployments) => {
     console.log(deployments);

--- a/README.hbs
+++ b/README.hbs
@@ -1,6 +1,10 @@
 # 𝚫 now API [![Build Status](https://travis-ci.org/timolins/now-api.svg)](https://travis-ci.org/timolins/now-api)
 
-Node.js module to interact with the official [𝚫 now API](https://zeit.co/api). You need to provide your API token, which you can find in `~/.now.json`.
+Node.js module to interact with the official [𝚫 now API](https://zeit.co/api).
+
+You need to provide your API token, which you can obtain [here](https://zeit.co/account#api-tokens).
+It is possible to pass it as a parameter or with the `NOW_TOKEN` environment variable.
+When no token is given, it will use the one contained in your `.now.json` file.
 
 ```sh
 npm install --save now-api
@@ -12,8 +16,6 @@ npm install --save now-api
 var Now = require('now-api');
 
 var now = Now('YOUR TOKEN');
-
-If you don't supply 'YOUR TOKEN', it will be searched for in ~/.now.json
 
 // Supports Promises
 now.getDeployments().then((deployments) => {

--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
 # 𝚫 now API [![Build Status](https://travis-ci.org/timolins/now-api.svg)](https://travis-ci.org/timolins/now-api)
 
-Node.js module to interact with the official [𝚫 now API](https://zeit.co/api). You need to provide your API token, which you can find in `~/.now.json`.
+Node.js module to interact with the official [𝚫 now API](https://zeit.co/api).
+
+You need to provide your API token, which you can obtain [here](https://zeit.co/account#api-tokens).
+It is possible to pass it as a parameter or with the `NOW_TOKEN` environment variable.
+When no token is given, it will use the one contained in your `.now.json` file.
 
 ```sh
 npm install --save now-api
@@ -32,7 +36,7 @@ now.getDeployments(function(err, deployments) {
 **Kind**: global class  
 
 * [Now](#Now)
-    * [new Now(token)](#new_Now_new)
+    * [new Now([token])](#new_Now_new)
     * [.getDeployments([callback])](#Now+getDeployments) ⇒ <code>Promise</code>
     * [.getDeployment(id, [callback])](#Now+getDeployment) ⇒ <code>Promise</code>
     * [.createDeployment(body, [callback])](#Now+createDeployment) ⇒ <code>Promise</code>
@@ -45,13 +49,13 @@ now.getDeployments(function(err, deployments) {
 
 <a name="new_Now_new"></a>
 
-### new Now(token)
-Initializes the API.
+### new Now([token])
+Initializes the API. Looks for token in ~/.now.json if none is provided.
 
 
 | Param | Type | Description |
 | --- | --- | --- |
-| token | <code>String</code> | Your now API token. |
+| [token] | <code>String</code> | Your now API token. |
 
 <a name="Now+getDeployments"></a>
 

--- a/package.json
+++ b/package.json
@@ -16,6 +16,9 @@
   "eslintConfig": {
     "parser": "babel-eslint",
     "extends": "airbnb",
+    "rules": {
+      "no-console": 0
+    },
     "plugins": [
       "mocha"
     ],

--- a/src/now.js
+++ b/src/now.js
@@ -1,3 +1,6 @@
+const path = require('path');
+const os = require('os');
+
 const axios = require('axios');
 
 const ERROR = {
@@ -24,19 +27,37 @@ const ERROR = {
 };
 
 /**
+ * Tries to obtain the API token and returns it.
+ * If NOW_TOKEN isn't defined, it will search in the user's home directory
+ * @return {String} – now API Token
+ */
+function _getToken() {
+  let token = process.env.NOW_TOKEN;
+
+  if (!token) {
+    try {
+      const configPath = path.join(os.homedir(), '.now.ajson');
+      token = require(configPath).token; // eslint-disable-line global-require
+    } catch (e) {
+      console.error(`Error: ${e}`);
+    }
+  }
+  return token;
+}
+
+
+/**
  * Initializes the API. Looks for token in ~/.now.json if none is provided.
  * @constructor
  * @param {String} [token] - Your now API token.
  */
-function Now(token) {
+function Now(token = _getToken()) {
   if (!token) {
-    try {
-      token = require(require('path').join(require('os').homedir(), '.now.json')).token
-    } catch (e) {
-      console.error(`Must either supply token argument or hold it in the user's home directory in ".now.json" file.`)
-      console.error(`Error: ${e}`)
-      return
-    }
+    return console.error(
+      'No token found! ' +
+      'Supply it as argument or use the NOW_TOKEN env variable. ' +
+      '".now.json" will be used, if it\'s found in your home directory.'
+    );
   }
   if (!(this instanceof Now)) return new Now(token);
   this.token = token;

--- a/src/now.js
+++ b/src/now.js
@@ -24,11 +24,20 @@ const ERROR = {
 };
 
 /**
- * Initializes the API.
+ * Initializes the API. Looks for token in ~/.now.json if none is provided.
  * @constructor
- * @param {String} token - Your now API token.
+ * @param {String} [token] - Your now API token.
  */
 function Now(token) {
+  if (!token) {
+    try {
+      token = require(require('path').join(require('os').homedir(), '.now.json')).token
+    } catch (e) {
+      console.error(`Must either supply token argument or hold it in the user's home directory in ".now.json" file.`)
+      console.error(`Error: ${e}`)
+      return
+    }
+  }
   if (!(this instanceof Now)) return new Now(token);
   this.token = token;
   this.axios = axios.create({


### PR DESCRIPTION
The API token can now be supplied through the `NOW_TOKEN` environment variable. If it isn't, it will be searched for in `~/.now.

Thanks to @millette!